### PR TITLE
Add confirmations column to Transactions Table.

### DIFF
--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -506,7 +506,7 @@ void RPC::refreshReceivedZTrans(QList<QString> zaddrs) {
                             }
                             
                             auto amount        = i["amount"].get<json::number_float_t>();
-                            auto confirmations = (unsigned long)txidInfo["confirmations"].get<json::number_unsigned_t>();                            
+                            auto confirmations = static_cast<long>(txidInfo["confirmations"].get<json::number_integer_t>());
 
                             TransactionItem tx{ QString("receive"), timestamp, zaddr, txid, amount, 
                                                 confirmations, "", memos.value(zaddr + txid, "") };
@@ -879,7 +879,7 @@ void RPC::refreshTransactions() {
                 address,
                 QString::fromStdString(it["txid"]),
                 it["amount"].get<json::number_float_t>() + fee,
-                (unsigned long)it["confirmations"].get<json::number_unsigned_t>(),
+                static_cast<long>(it["confirmations"].get<json::number_unsigned_t>()),
                 "", "" };
 
             txdata.push_back(tx);
@@ -936,7 +936,7 @@ void RPC::refreshSentZTrans() {
                     continue;
                 auto error = j["confirmations"].is_null();
                 if (!error)
-                    sentTx.confirmations = j["confirmations"].get<json::number_unsigned_t>();
+                    sentTx.confirmations = j["confirmations"].get<json::number_integer_t>();
             }
             
             transactionsTableModel->addZSentData(newSentZTxs);

--- a/src/rpc.h
+++ b/src/rpc.h
@@ -19,7 +19,7 @@ struct TransactionItem {
     QString         address;
     QString         txid;
     double          amount;
-    unsigned long   confirmations;
+    long   confirmations;
     QString         fromAddr;
     QString         memo;
 };

--- a/src/txtablemodel.cpp
+++ b/src/txtablemodel.cpp
@@ -4,7 +4,7 @@
 
 TxTableModel::TxTableModel(QObject *parent)
      : QAbstractTableModel(parent) {
-    headers << QObject::tr("Type") << QObject::tr("Address") << QObject::tr("Date/Time") << QObject::tr("Amount");
+    headers << QObject::tr("Type") << QObject::tr("Address") << QObject::tr("Date/Time") << QObject::tr("Confirmations") << QObject::tr("Amount");
 }
 
 TxTableModel::~TxTableModel() {
@@ -104,8 +104,8 @@ void TxTableModel::updateAllData() {
 
  QVariant TxTableModel::data(const QModelIndex &index, int role) const
  {
-     // Align column 4 (amount) right
-    if (role == Qt::TextAlignmentRole && index.column() == 3) return QVariant(Qt::AlignRight | Qt::AlignVCenter);
+     // Align column 5 (amount) right
+    if (role == Qt::TextAlignmentRole && index.column() >= 3) return QVariant(Qt::AlignRight | Qt::AlignVCenter);
     
     if (role == Qt::ForegroundRole) {
         if (modeldata->at(index.row()).confirmations == 0) {
@@ -125,14 +125,15 @@ void TxTableModel::updateAllData() {
         switch (index.column()) {
         case 0: return dat.type;
         case 1: { 
-                    auto addr = modeldata->at(index.row()).address;
+                    auto addr = dat.address;
                     if (addr.trimmed().isEmpty()) 
                         return "(Shielded)";
                     else 
                         return addr;
                 }
-        case 2: return QDateTime::fromMSecsSinceEpoch(modeldata->at(index.row()).datetime *  (qint64)1000).toLocalTime().toString();
-        case 3: return Settings::getZECDisplayFormat(modeldata->at(index.row()).amount);
+        case 2: return QDateTime::fromMSecsSinceEpoch(dat.datetime *  (qint64)1000).toLocalTime().toString();
+        case 3: return QString::number(dat.confirmations);
+        case 4: return Settings::getZECDisplayFormat(dat.amount);
         }
     } 
 
@@ -154,7 +155,8 @@ void TxTableModel::updateAllData() {
                         return addr;
                 }
         case 2: return QDateTime::fromMSecsSinceEpoch(modeldata->at(index.row()).datetime * (qint64)1000).toLocalTime().toString();
-        case 3: return Settings::getInstance()->getUSDFromZecAmount(modeldata->at(index.row()).amount);
+        case 3: return QString("%1 Network Confirmations").arg(QString::number(dat.confirmations));
+        case 4: return Settings::getInstance()->getUSDFromZecAmount(modeldata->at(index.row()).amount);
         }    
     }
 
@@ -183,7 +185,7 @@ void TxTableModel::updateAllData() {
 
  QVariant TxTableModel::headerData(int section, Qt::Orientation orientation, int role) const
  {
-     if (role == Qt::TextAlignmentRole && section == 3) return QVariant(Qt::AlignRight | Qt::AlignVCenter);
+     if (role == Qt::TextAlignmentRole && section == 4) return QVariant(Qt::AlignRight | Qt::AlignVCenter);
 
      if (role == Qt::FontRole) {
          QFont f;

--- a/src/txtablemodel.cpp
+++ b/src/txtablemodel.cpp
@@ -106,9 +106,10 @@ void TxTableModel::updateAllData() {
  {
      // Align column 5 (amount) right
     if (role == Qt::TextAlignmentRole && index.column() >= 3) return QVariant(Qt::AlignRight | Qt::AlignVCenter);
-    
+
+    auto dat = modeldata->at(index.row());
     if (role == Qt::ForegroundRole) {
-        if (modeldata->at(index.row()).confirmations == 0) {
+        if (dat.confirmations <= 0) {
             QBrush b;
             b.setColor(Qt::red);
             return b;
@@ -120,7 +121,6 @@ void TxTableModel::updateAllData() {
         return b;        
     }
 
-    auto dat = modeldata->at(index.row());
     if (role == Qt::DisplayRole) {
         switch (index.column()) {
         case 0: return dat.type;


### PR DESCRIPTION
Show confirmation count for each transaction in the table. Small refactor to use already copied index item for the column data instead of grabbing from the list.