### PR TITLE
Fix T-addresses not showing up in dropdown

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1309,12 +1309,17 @@ void MainWindow::setupReceiveTab() {
 
     // View all addresses goes to "View all private keys"
     QObject::connect(ui->btnViewAllAddresses, &QPushButton::clicked, [=] () {
+        // If there's no RPC, return
+        if (!getRPC())
+            return;
+
         QDialog d(this);
         Ui_ViewAddressesDialog viewaddrs;
         viewaddrs.setupUi(&d);
         Settings::saveRestore(&d);
+        Settings::saveRestoreTableHeader(viewaddrs.tblAddresses, &d, "viewalladdressestable");
 
-        ViewAllAddressesModel model(viewaddrs.tblAddresses, *getRPC()->getAllTAddresses());
+        ViewAllAddressesModel model(viewaddrs.tblAddresses, *getRPC()->getAllTAddresses(), getRPC());
         viewaddrs.tblAddresses->setModel(&model);
 
         viewaddrs.tblAddresses->setContextMenuPolicy(Qt::CustomContextMenu);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -427,15 +427,15 @@ void MainWindow::setupStatusBar() {
 
         if (!msg.isEmpty() && msg.startsWith(Settings::txidStatusMessage)) {
             auto txid = msg.split(":")[1].trimmed();
-            menu.addAction("Copy txid", [=]() {
+            menu.addAction(tr("Copy txid"), [=]() {
                 QGuiApplication::clipboard()->setText(txid);
             });
-            menu.addAction("View tx on block explorer", [=]() {
+            menu.addAction(tr("View tx on block explorer"), [=]() {
                 Settings::openTxInExplorer(txid);
             });
         }
 
-        menu.addAction("Refresh", [=]() {
+        menu.addAction(tr("Refresh"), [=]() {
             rpc->refresh(true);
         });
         QPoint gpos(mapToGlobal(pos).x(), mapToGlobal(pos).y() + this->height() - ui->statusBar->height());
@@ -982,7 +982,7 @@ void MainWindow::exportKeys(QString addr) {
 
     Settings::saveRestore(&d);
 
-    pui.privKeyTxt->setPlainText(tr("Loading..."));
+    pui.privKeyTxt->setPlainText(tr("This might take several minutes. Loading..."));
     pui.privKeyTxt->setReadOnly(true);
     pui.privKeyTxt->setLineWrapMode(QPlainTextEdit::LineWrapMode::NoWrap);
 
@@ -1322,22 +1322,26 @@ void MainWindow::setupReceiveTab() {
         ViewAllAddressesModel model(viewaddrs.tblAddresses, *getRPC()->getAllTAddresses(), getRPC());
         viewaddrs.tblAddresses->setModel(&model);
 
+        QObject::connect(viewaddrs.btnExportAll, &QPushButton::clicked,  this, &MainWindow::exportAllKeys);
+
         viewaddrs.tblAddresses->setContextMenuPolicy(Qt::CustomContextMenu);
         QObject::connect(viewaddrs.tblAddresses, &QTableView::customContextMenuRequested, [=] (QPoint pos) {
             QModelIndex index = viewaddrs.tblAddresses->indexAt(pos);
             if (index.row() < 0) return;
 
             index = index.sibling(index.row(), 0);
+            QString addr = viewaddrs.tblAddresses->model()->data(index).toString();
 
             QMenu menu(this);
-            menu.addAction(tr("Export Private Key"), [=] () {
-                QString addr = viewaddrs.tblAddresses->model()->data(index).toString();
+            menu.addAction(tr("Export Private Key"), [=] () {                
                 if (addr.isEmpty())
                     return;
 
                 this->exportKeys(addr);
             });
-
+            menu.addAction(tr("Copy Address"), [=]() {
+                QGuiApplication::clipboard()->setText(addr);
+            });
             menu.exec(viewaddrs.tblAddresses->viewport()->mapToGlobal(pos));
         });
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -176,6 +176,14 @@ void Settings::saveRestore(QDialog* d) {
     });
 }
 
+void Settings::saveRestoreTableHeader(QTableView* table, QDialog* d, QString tablename) {
+    table->horizontalHeader()->restoreState(QSettings().value(tablename).toByteArray());
+
+    QObject::connect(d, &QDialog::finished, [=](auto) {
+        QSettings().setValue(tablename, table->horizontalHeader()->saveState());
+    });
+}
+
 void Settings::openAddressInExplorer(QString address) {
     QString url;
     if (Settings::getInstance()->isTestnet()) {

--- a/src/settings.h
+++ b/src/settings.h
@@ -82,6 +82,7 @@ public:
     static const QString txidStatusMessage;
     
     static void saveRestore(QDialog* d);
+    static void saveRestoreTableHeader(QTableView* table, QDialog* d, QString tablename) ;
 
     static void openAddressInExplorer(QString address);
     static void openTxInExplorer(QString txid);

--- a/src/viewalladdresses.cpp
+++ b/src/viewalladdresses.cpp
@@ -1,9 +1,11 @@
 #include "viewalladdresses.h"
+#include "settings.h"
 
-ViewAllAddressesModel::ViewAllAddressesModel(QTableView *parent, QList<QString> taddrs)
+ViewAllAddressesModel::ViewAllAddressesModel(QTableView *parent, QList<QString> taddrs, RPC* rpc)
      : QAbstractTableModel(parent) {
-    headers << tr("Address");
+    headers << tr("Address") << tr("Balance (%1)").arg(Settings::getTokenName());
     addresses = taddrs;
+    this->rpc = rpc;
 }
 
 
@@ -16,9 +18,11 @@ int ViewAllAddressesModel::columnCount(const QModelIndex&) const {
 }
 
 QVariant ViewAllAddressesModel::data(const QModelIndex &index, int role) const {
+    QString address = addresses.at(index.row());
     if (role == Qt::DisplayRole) {
         switch(index.column()) {
-            case 0: return addresses.at(index.row());
+            case 0: return address;
+            case 1: return rpc->getAllBalances()->value(address, 0.0);
         }
     }
     return QVariant();

--- a/src/viewalladdresses.cpp
+++ b/src/viewalladdresses.cpp
@@ -1,0 +1,34 @@
+#include "viewalladdresses.h"
+
+ViewAllAddressesModel::ViewAllAddressesModel(QTableView *parent, QList<QString> taddrs)
+     : QAbstractTableModel(parent) {
+    headers << tr("Address");
+    addresses = taddrs;
+}
+
+
+int ViewAllAddressesModel::rowCount(const QModelIndex&) const {
+    return addresses.size();
+}
+
+int ViewAllAddressesModel::columnCount(const QModelIndex&) const {
+    return headers.size();
+}
+
+QVariant ViewAllAddressesModel::data(const QModelIndex &index, int role) const {
+    if (role == Qt::DisplayRole) {
+        switch(index.column()) {
+            case 0: return addresses.at(index.row());
+        }
+    }
+    return QVariant();
+}  
+
+
+QVariant ViewAllAddressesModel::headerData(int section, Qt::Orientation orientation, int role) const {
+    if (role == Qt::DisplayRole && orientation == Qt::Horizontal) {
+        return headers.at(section);
+    }
+
+    return QVariant();
+}

--- a/src/viewalladdresses.h
+++ b/src/viewalladdresses.h
@@ -1,0 +1,22 @@
+#ifndef VIEWALLADDRESSES_H
+#define VIEWALLADDRESSES_H
+
+#include "precompiled.h"
+
+class ViewAllAddressesModel : public QAbstractTableModel {
+
+public:
+    ViewAllAddressesModel(QTableView* parent, QList<QString> taddrs);
+    ~ViewAllAddressesModel() = default;
+
+    int      rowCount(const QModelIndex &parent) const;
+    int      columnCount(const QModelIndex &parent) const;
+    QVariant data(const QModelIndex &index, int role) const;
+    QVariant headerData(int section, Qt::Orientation orientation, int role) const;
+
+private:
+    QList<QString> addresses;
+    QStringList headers;    
+};
+
+#endif

--- a/src/viewalladdresses.h
+++ b/src/viewalladdresses.h
@@ -2,11 +2,12 @@
 #define VIEWALLADDRESSES_H
 
 #include "precompiled.h"
+#include "rpc.h"
 
 class ViewAllAddressesModel : public QAbstractTableModel {
 
 public:
-    ViewAllAddressesModel(QTableView* parent, QList<QString> taddrs);
+    ViewAllAddressesModel(QTableView* parent, QList<QString> taddrs, RPC* rpc);
     ~ViewAllAddressesModel() = default;
 
     int      rowCount(const QModelIndex &parent) const;
@@ -17,6 +18,7 @@ public:
 private:
     QList<QString> addresses;
     QStringList headers;    
+    RPC* rpc;
 };
 
 #endif

--- a/src/viewalladdresses.ui
+++ b/src/viewalladdresses.ui
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ViewAddressesDialog</class>
+ <widget class="QDialog" name="ViewAddressesDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>All Addresses</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QTableView" name="tblAddresses">
+     <property name="selectionMode">
+      <enum>QAbstractItemView::SingleSelection</enum>
+     </property>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ViewAddressesDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ViewAddressesDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/viewalladdresses.ui
+++ b/src/viewalladdresses.ui
@@ -14,17 +14,7 @@
    <string>All Addresses</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QTableView" name="tblAddresses">
-     <property name="selectionMode">
-      <enum>QAbstractItemView::SingleSelection</enum>
-     </property>
-     <attribute name="horizontalHeaderStretchLastSection">
-      <bool>true</bool>
-     </attribute>
-    </widget>
-   </item>
-   <item row="1" column="0">
+   <item row="1" column="1">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -32,6 +22,23 @@
      <property name="standardButtons">
       <set>QDialogButtonBox::Ok</set>
      </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QPushButton" name="btnExportAll">
+     <property name="text">
+      <string>Export All Keys</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QTableView" name="tblAddresses">
+     <property name="selectionMode">
+      <enum>QAbstractItemView::SingleSelection</enum>
+     </property>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
     </widget>
    </item>
   </layout>

--- a/zec-qt-wallet.pro
+++ b/zec-qt-wallet.pro
@@ -57,7 +57,8 @@ SOURCES += \
     src/mobileappconnector.cpp \
     src/recurring.cpp \
     src/requestdialog.cpp \
-    src/memoedit.cpp
+    src/memoedit.cpp \
+    src/viewalladdresses.cpp
 
 HEADERS += \
     src/mainwindow.h \
@@ -82,7 +83,8 @@ HEADERS += \
     src/mobileappconnector.h \
     src/recurring.h \
     src/requestdialog.h \
-    src/memoedit.h
+    src/memoedit.h \
+    src/viewalladdresses.h
 
 FORMS += \
     src/mainwindow.ui \
@@ -95,6 +97,7 @@ FORMS += \
     src/turnstileprogress.ui \
     src/privkey.ui \
     src/memodialog.ui \ 
+    src/viewalladdresses.ui \
     src/connection.ui \
     src/zboard.ui \
     src/addressbook.ui \


### PR DESCRIPTION
* Add t-addresses in the t-addr dropdown by default (upto 20)
* Make "View all" button go to new dialogbox with addresses
* Still allow exporting all keys