### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
           packages: ['clang-3.7', 'g++-8']
 
 before_install:
- - sudo add-apt-repository ppa:beineri/opt-qt591-trusty -y
+ - sudo add-apt-repository ppa:beineri/opt-qt591-xenial -y
  - sudo apt-get update -qq
  - sudo apt-get install qt59base qt59websockets 
  - source /opt/qt59/bin/qt59-env.sh


### PR DESCRIPTION
Build server is obviously upgraded to Ubuntu 16.04, travis build is failing because of outdated qt591 repository.