### PR TITLE
style sheet reset

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1648,6 +1648,7 @@ void MainWindow::slot_change_theme(const QString& theme_name)
     if (qFile.open(QFile::ReadOnly))
     {
       QString styleSheet = QLatin1String(qFile.readAll());
+      this->setStyleSheet(""); // reset styles    
       this->setStyleSheet(styleSheet);
     }
 


### PR DESCRIPTION
Style sheet reset before the theme change makes all widgets styles update without restart requirement. 
Tested on a fork (Safecoin Qt wallet), but it should work for you as well.