### PR TITLE
Comment out downloading the Sprout keys since they were deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ ZecWallet needs a Zcash node running zcashd. If you already have a zcashd node r
 
 If you don't have one, ZecWallet will start its embedded zcashd node. 
 
-Additionally, if this is the first time you're running ZecWallet or a zcashd daemon, ZecWallet will download the zcash params (~1.7 GB) and configure `zcash.conf` for you. 
+Additionally, if this is the first time you're running ZecWallet or a zcashd daemon, ZecWallet will download the Zcash params (~777 MB) and configure `zcash.conf` for you. 
 
 Pass `--no-embedded` to disable the embedded zcashd and force ZecWallet to connect to an external node.
 

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -219,10 +219,11 @@ void ConnectionLoader::downloadParams(std::function<void(void)> cb) {
     client = new QNetworkAccessManager(main);   
     
     downloadQueue->enqueue(QUrl("https://z.cash/downloads/sapling-output.params"));
-    downloadQueue->enqueue(QUrl("https://z.cash/downloads/sapling-spend.params"));    
-    downloadQueue->enqueue(QUrl("https://z.cash/downloads/sprout-proving.key"));
-    downloadQueue->enqueue(QUrl("https://z.cash/downloads/sprout-verifying.key"));
+    downloadQueue->enqueue(QUrl("https://z.cash/downloads/sapling-spend.params"));  
     downloadQueue->enqueue(QUrl("https://z.cash/downloads/sprout-groth16.params"));
+    // Comment out downloading the Sprout keys because they were deprecated with https://github.com/zcash/zcash/pull/4060
+    // downloadQueue->enqueue(QUrl("https://z.cash/downloads/sprout-proving.key"));
+    // downloadQueue->enqueue(QUrl("https://z.cash/downloads/sprout-verifying.key"));
 
     doNextDownload(cb);    
 }
@@ -567,9 +568,10 @@ bool ConnectionLoader::verifyParams() {
 
     if (!QFile(paramsDir.filePath("sapling-output.params")).exists()) return false;
     if (!QFile(paramsDir.filePath("sapling-spend.params")).exists()) return false;
-    if (!QFile(paramsDir.filePath("sprout-proving.key")).exists()) return false;
-    if (!QFile(paramsDir.filePath("sprout-verifying.key")).exists()) return false;
     if (!QFile(paramsDir.filePath("sprout-groth16.params")).exists()) return false;
+    // Comment out downloading the Sprout keys because they were deprecated with https://github.com/zcash/zcash/pull/4060
+    // if (!QFile(paramsDir.filePath("sprout-proving.key")).exists()) return false;
+    // if (!QFile(paramsDir.filePath("sprout-verifying.key")).exists()) return false;
 
     return true;
 }


### PR DESCRIPTION
As per https://github.com/zcash/zcash/blob/98b70f12645098880fb9543dee6726b277d194cf/zcutil/fetch-params.sh#L214

For this to work, you need to update `zcashd` to latest version too.