### PR TITLE
Prevent rendering of HTML in received memos

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -917,6 +917,9 @@ void MainWindow::setupTransactionsTab() {
 
         if (!memo.isEmpty()) {
             QMessageBox mb(QMessageBox::Information, tr("Memo"), memo, QMessageBox::Ok, this);
+            // Don't render html in the memo to avoid phishing-type attacks
+            // revist this in the future once the design  of how to best handle memo based applications exists.
+            mb.setTextFormat(Qt::PlainText);
             mb.setTextInteractionFlags(Qt::TextSelectableByMouse | Qt::TextSelectableByKeyboard);
             mb.exec();
         }
@@ -965,6 +968,9 @@ void MainWindow::setupTransactionsTab() {
         if (!memo.isEmpty()) {
             menu.addAction(tr("View Memo"), [=] () {               
                 QMessageBox mb(QMessageBox::Information, tr("Memo"), memo, QMessageBox::Ok, this);
+                // Don't render html in the memo to avoid phishing-type attacks
+                // revist this in the future once the design  of how to best handle memo based applications exists.
+                mb.setTextFormat(Qt::PlainText);
                 mb.setTextInteractionFlags(Qt::TextSelectableByMouse | Qt::TextSelectableByKeyboard);
                 mb.exec();
             });

--- a/src/txtablemodel.cpp
+++ b/src/txtablemodel.cpp
@@ -145,8 +145,9 @@ void TxTableModel::updateAllData() {
                     if (dat.memo.startsWith("zcash:")) {
                         return Settings::paymentURIPretty(Settings::parseURI(dat.memo));
                     } else {
+                        // Don't render memo html in tooltip
                         return modeldata->at(index.row()).type + 
-                        (dat.memo.isEmpty() ? "" : " tx memo: \"" + dat.memo + "\"");
+                        (dat.memo.isEmpty() ? "" : " tx memo: \"" + dat.memo.toHtmlEscaped() + "\"");
                     }
                 }
         case Column::Address: {


### PR DESCRIPTION
See: #205 - This patch changes the rendering of html memos to something like this. (This might be a little more draconian than necessary but I didn't want to implement anything more flexible until more discussion had taken place.)

![Screenshot_20191126_124604](https://user-images.githubusercontent.com/106626/69672122-4a665200-104c-11ea-8cb1-4ae0929c8a1c.png)
