### PR TITLE
Pass -dead_strip and -dead_strip_dylibs

### DIFF
--- a/zec-qt-wallet.pro
+++ b/zec-qt-wallet.pro
@@ -29,6 +29,7 @@ INCLUDEPATH  += src/
 
 LIBS+= -Wl,-dead_strip
 LIBS+= -Wl,-dead_strip_dylibs
+LIBS+= -Wl,-bind_at_load
 
 RESOURCES     = application.qrc
 

--- a/zec-qt-wallet.pro
+++ b/zec-qt-wallet.pro
@@ -27,6 +27,9 @@ DEFINES += \
 INCLUDEPATH  += src/3rdparty/
 INCLUDEPATH  += src/
 
+LIBS+= -Wl,-dead_strip
+LIBS+= -Wl,-dead_strip_dylibs
+
 RESOURCES     = application.qrc
 
 MOC_DIR = bin


### PR DESCRIPTION
From `man ld`.
```
-dead_strip
                 Remove functions and data that are unreachable by the entry point or exported symbols.
```

Before:
<img width="860" alt="Screen Shot 2020-01-12 at 17 18 38" src="https://user-images.githubusercontent.com/227442/72221306-024eb080-3562-11ea-885b-e93d2f276630.png">
After:
<img width="856" alt="Screen Shot 2020-01-12 at 17 29 36" src="https://user-images.githubusercontent.com/227442/72221309-0975be80-3562-11ea-87bf-d1991c0fba83.png">

From `man ld`.
```
-dead_strip_dylibs
                 Remove dylibs that are unreachable by the entry point or exported symbols. That is, suppresses the generation of load
                 command commands for dylibs which supplied no symbols during the link. This option should not be used when linking
                 against a dylib which is required at runtime for some indirect reason such as the dylib has an important initializer.
```

Before:
```
$ otool -L zecwallet.app/Contents/MacOS/zecwallet
/opt/local/libexec/qt5/lib/QtWidgets.framework/Versions/5/QtWidgets (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtGui.framework/Versions/5/QtGui (compatibility version 5.14.0, current version 5.14.0)
	/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit (compatibility version 45.0.0, current version 1894.10.126)
	/System/Library/Frameworks/Metal.framework/Versions/A/Metal (compatibility version 1.0.0, current version 212.2.3)
	/opt/local/libexec/qt5/lib/QtWebSockets.framework/Versions/5/QtWebSockets (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtNetwork.framework/Versions/5/QtNetwork (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtCore.framework/Versions/5/QtCore (compatibility version 5.14.0, current version 5.14.0)
	/System/Library/Frameworks/DiskArbitration.framework/Versions/A/DiskArbitration (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit (compatibility version 1.0.0, current version 275.0.0)
	/System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/AGL.framework/Versions/A/AGL (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 800.7.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
```
After:
```
$ otool -L zecwallet.app/Contents/MacOS/zecwallet
        /opt/local/libexec/qt5/lib/QtWidgets.framework/Versions/5/QtWidgets (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtGui.framework/Versions/5/QtGui (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtWebSockets.framework/Versions/5/QtWebSockets (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtNetwork.framework/Versions/5/QtNetwork (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtCore.framework/Versions/5/QtCore (compatibility version 5.14.0, current version 5.14.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 800.7.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
```