### PR TITLE
Fixed typo in Routes.js import message

### DIFF
--- a/app/Routes.js
+++ b/app/Routes.js
@@ -199,7 +199,7 @@ export default class RouteApp extends React.Component<Props, AppState> {
           <span>
             The import process for the private keys has started.
             <br />
-            This will take a long time, upto 6 hours!
+            This will take a long time, up to 6 hours!
             <br />
             Please be patient!
           </span>


### PR DESCRIPTION
"upto" --> "up to"