### PR TITLE
fix "Export All Private Keys" private keys menu item from missing addresses

### DIFF
--- a/app/rpc.js
+++ b/app/rpc.js
@@ -421,16 +421,13 @@ export default class RPC {
     const zaddrsPromise = RPC.doRPC('z_listaddresses', [], this.rpcConfig);
     const taddrs1Promise = RPC.doRPC('getaddressesbyaccount', [''], this.rpcConfig);
     const taddrs2Promise = RPC.doRPC('listaddressgroupings', [], this.rpcConfig);
+
     const allZ = (await zaddrsPromise).result;
-    const allT = (await taddrs1Promise).result;
-    const allT2 = (await taddrs2Promise).result;
-    for (let i = 0; i < allT2.length; i += 1) {
-      const arrayT = allT2[i];
-      for (let e = 0; e < arrayT.length; e += 1) {
-        const taddr = arrayT[e][0];
-        if (allT.indexOf(taddr) === -1) allT.push(taddr);
-      }
-    }
+
+    const t1 = (await taddrs1Promise).result;
+    const t2 = (await taddrs2Promise).result.map(a => a[0]).map(a => a[0]);
+    const allT = [...new Set(t1.concat(t2))];
+
     this.fnSetAllAddresses(allZ.concat(allT));
   }
 

--- a/app/rpc.js
+++ b/app/rpc.js
@@ -235,7 +235,7 @@ export default class RPC {
       }
     } else {
       try {
-        const r = await RPC.doRPC('importprivkey', [key, 'imported', rescan], this.rpcConfig);
+        const r = await RPC.doRPC('importprivkey', [key, '', rescan], this.rpcConfig);
         console.log(r.result);
         return '';
       } catch (err) {
@@ -419,11 +419,18 @@ export default class RPC {
   // Get all Addresses, including T and Z addresses
   async fetchAllAddresses() {
     const zaddrsPromise = RPC.doRPC('z_listaddresses', [], this.rpcConfig);
-    const taddrsPromise = RPC.doRPC('getaddressesbyaccount', [''], this.rpcConfig);
-
+    const taddrs1Promise = RPC.doRPC('getaddressesbyaccount', [''], this.rpcConfig);
+    const taddrs2Promise = RPC.doRPC('listaddressgroupings', [], this.rpcConfig);
     const allZ = (await zaddrsPromise).result;
-    const allT = (await taddrsPromise).result;
-
+    const allT = (await taddrs1Promise).result;
+    const allT2 = (await taddrs2Promise).result;
+    for (let i = 0; i < allT2.length; i += 1) {
+      const arrayT = allT2[i];
+      for (let e = 0; e < arrayT.length; e += 1) {
+        const taddr = arrayT[e][0];
+        if (allT.indexOf(taddr) === -1) allT.push(taddr);
+      }
+    }
     this.fnSetAllAddresses(allZ.concat(allT));
   }
 


### PR DESCRIPTION
Fixes `Export All Private Keys` menu item from not exporting private keys for change addresses and any imported addresses. The other addresses show up on the `listaddressgroupings` rpc call, so included that, parsed, and pushed any addresses not already in `allT` array into the array to be included in the final address list concatenated to the allZ address list

further details issue #295 